### PR TITLE
feat: add rate limiter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask==3.0.3
 Flask-Cors==6.0.0
+Flask-Limiter==3.5.1
 Pillow==10.3.0
 numpy==1.26.4
 python-dotenv==1.0.1

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,6 +3,7 @@ from flask_cors import CORS
 
 from src.config import DevelopmentConfig, ProductionConfig
 from src.api.v1.endpoints import api_v1
+from src.extensions import limiter
 
 from src.model.lung_analyzer import LungAnalyzer
 
@@ -19,6 +20,9 @@ def create_app(config_name="development"):
 
     # Enable CORS
     CORS(app, resources={r"/api/*": {"origins": app.config.get("CORS_ORIGINS", "*")}})
+
+    # Initialize extensions
+    limiter.init_app(app)
 
     # Initialize lung analyzer model
     initialize_model(app)

--- a/src/api/v1/endpoints.py
+++ b/src/api/v1/endpoints.py
@@ -4,6 +4,7 @@ import traceback
 from flask import jsonify, current_app, request
 from typing import Dict
 from . import api_v1
+from src.extensions import limiter
 
 
 @api_v1.route("/health")
@@ -38,6 +39,7 @@ def get_pathologies():
 
 
 @api_v1.route('/analyze', methods=['POST'])
+@limiter.limit("10 per minute")
 def analyze_lung_scan():
     """
     Analyze lung X-ray image for pathologies.

--- a/src/extensions.py
+++ b/src/extensions.py
@@ -1,0 +1,8 @@
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+limiter = Limiter(
+    key_func=get_remote_address,
+    default_limits=["200 per day", "50 per hour"],
+    storage_uri="memory://",
+) 


### PR DESCRIPTION
- Add rate limiter with default of 200 per day, 50 per hour, saved in memory.
- Add analyze endpoint limit of 10 requests per minute to avoid heavy usage of computing power on the server

closes #5 